### PR TITLE
correct uint64 type in formats_i.c

### DIFF
--- a/src/formats_i.c
+++ b/src/formats_i.c
@@ -138,7 +138,7 @@ size_t lsx_writebuf(sox_format_t * ft, void const * buf, size_t len)
   return ret;
 }
 
-uint64_t lsx_filelength(sox_format_t * ft)
+sox_uint64_t lsx_filelength(sox_format_t * ft)
 {
   struct stat st;
   int ret = ft->fp ? fstat(fileno((FILE*)ft->fp), &st) : 0;


### PR DESCRIPTION
On mac os X
```
➜  sox git:(mac_patch_uint64type) uname -a
Darwin e1r4p18.42.fr 16.7.0 Darwin Kernel Version 16.7.0: Thu Jun 15 17:36:27 PDT 2017; root:xnu-3789.70.16~2/RELEASE_X86_64 x86_64
```

I had to do that correction in order to compile