### PR TITLE
Fix `property_size = sizeof(name)`

### DIFF
--- a/src/coreaudio.c
+++ b/src/coreaudio.c
@@ -152,6 +152,7 @@ static int setup(sox_format_t *ft, int is_input)
               for (i = 0; i < device_count; i++)
               {
                   char name[256];
+                  property_size = sizeof(name);
                   status = AudioDeviceGetProperty(devices[i],0,false,kAudioDevicePropertyDeviceName,&property_size,&name);
 
                   lsx_report("Found Audio Device \"%s\"\n",name);


### PR DESCRIPTION
When I upgraded from Mojave to Monterey, I could no longer specify
a particular audio device using the [device enumeration hack](https://superuser.com/questions/1506208/sox-how-to-specify-audio-input-and-audio-output-devices-on-osx):

```
sox -V6 -n -t coreaudio bogus
```

(They *ALL* listed my HDMI monitor, not "External Headphones", etc.)

I tracked it down to a simple fix: resetting `property_size = sizeof(name)`

[N.B. This doesn't begin to address [replacing the deprecated `AudioHardwareGetProperty` APIs](https://stackoverflow.com/questions/1983984/how-to-get-audio-device-uid-to-pass-into-nssounds-setplaybackdeviceidentifier)]