### PR TITLE
Fix: delay buffer full flag assigned during drain

### DIFF
--- a/src/compand.c
+++ b/src/compand.c
@@ -250,6 +250,8 @@ static int drain(sox_effect_t * effp, sox_sample_t *obuf, size_t *osamp)
 
   if (l->delay_buf_full == 0)
     l->delay_buf_index = 0;
+
+  l->delay_buf_full = 1;
   while (done+effp->out_signal.channels <= *osamp && l->delay_buf_cnt > 0)
     for (chan = 0; chan < effp->out_signal.channels; ++chan) {
       int c = l->expectedChannels > 1 ? chan : 0;


### PR DESCRIPTION
in situations where the delay is quite large (e.g 20 seconds) and the input file is longer then that time,
the delay buffer full flag will not be true while draining, as a result it will always re-assign the delay buffer index to 0 resulting in not dumping all of the delay buffer.